### PR TITLE
config: set hostname

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,6 @@
 
 # Serve static files from /usr/share/caddy (mapped from ./site)
-localhost {
+mysite.local {
   root * /usr/share/caddy
   file_server
   tls internal


### PR DESCRIPTION
Change the hostname in the Caddyfile to mysite.local, requiring an update to the `/etc/hosts` file for proper resolution.